### PR TITLE
fix(grouped-require): skip linting for dynamic `require` assignments

### DIFF
--- a/lib/common/require-type.js
+++ b/lib/common/require-type.js
@@ -14,7 +14,8 @@ module.exports = {
 
 function isRequire(node) {
   const value = get(node, 'declarations.0.init.callee.name')
-  return !!(value && value === 'require')
+  const arg = get(node, 'declarations.0.init.arguments.0') || {}
+  return value === 'require' && arg.type === 'Literal'
 }
 
 function isStaticRequire(node) {

--- a/test/lib/rules/grouped-require.js
+++ b/test/lib/rules/grouped-require.js
@@ -11,10 +11,12 @@ test(RULE_NAME, async (t) => {
     valid: [
       {
         code: `
-          require('timers')
+          const dynamic = './something.js';
+          require('timers');
           run()
           const net = require('net');
           const http = require('http');
+          const something = require(dynamic)
           const {promisify} = require('util')
           const jquery = require('jquery');
           const bar = require('@foo/bar')


### PR DESCRIPTION
When linting require statements, the correct order cannot be determined
when the argument to `require` is a non-literal. This excludes those
from linting for variable assignments.

Fixes #3