### PR TITLE
Check static require in expressions

### DIFF
--- a/lib/common/require-type.js
+++ b/lib/common/require-type.js
@@ -4,7 +4,8 @@ const isBuiltinModule = require('is-builtin-module')
 const {get} = require('dot-prop')
 
 module.exports = {
-  isRequire
+  getRequiredModuleName
+, isRequire
 , isStaticRequire
 , isBuiltin
 , isScoped
@@ -39,12 +40,28 @@ function isBuiltin(node) {
   return !!(value && isBuiltinModule(value))
 }
 
+/**
+ * Determine if a given variable declaration or call expression
+ * node is a local require statement
+ * @param {'VariableDeclaration' | 'CallExpression'} node
+ * @returns
+ */
 function isLocal(node) {
-  const value = get(node, 'declarations.0.init.arguments.0.value')
+  const value = getRequiredModuleName(node)
   return !!(value && value.startsWith('.'))
 }
 
 function isTopLevel(node) {
   const value = get(node, 'parent.type')
   return !!(value && value === 'Program')
+}
+
+/**
+ * Returns the name of the module loaded in a require statement
+ * @param {'CallExpression' | 'VariableDeclaration'} node
+ * @returns
+ */
+function getRequiredModuleName(node) {
+  return get(node, 'declarations.0.init.arguments.0.value')
+    || get(node, 'arguments.0.value')
 }

--- a/lib/rules/require-file-extension.js
+++ b/lib/rules/require-file-extension.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const {get} = require('dot-prop')
 const {
-  isRequire
-, isLocal
+  isLocal,
+  isStaticRequire,
+  getRequiredModuleName
 } = require('../common/require-type.js')
 
 const REQUIRE_EXTENSIONS = new Set(['js', 'json', 'node'])
@@ -20,14 +20,14 @@ module.exports = {
     const nodes = []
 
     return {
-      VariableDeclaration(node) {
-        if (!isRequire(node)) return
+      CallExpression(node) {
+        if (!isStaticRequire(node)) return
         if (!isLocal(node)) return
         nodes.push(node)
       }
     , 'Program:exit'() {
         for (const node of nodes) {
-          const path = get(node, 'declarations.0.init.arguments.0.value')
+          const path = getRequiredModuleName(node)
           const parts = path.split('.')
           const hasExtension = parts.length > 1
             && REQUIRE_EXTENSIONS.has(parts[parts.length - 1])

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "homepage": "https://github.com/logdna/eslint-plugin-logdna#readme",
   "scripts": {
     "lint": "eslint ./",
+    "lint:fix": "eslint --fix ./",
     "tap": "tap",
     "pretest": "npm run lint",
     "test": "tap",

--- a/test/lib/rules/require-file-extension.js
+++ b/test/lib/rules/require-file-extension.js
@@ -17,19 +17,27 @@ test(RULE_NAME, async (t) => {
           if (bar) {
             const baz = require('./baz.json');
           }
+          registerTransform(require('./transforms/parse.js'))
+          module.exports = {
+            bar: require('./bar2.js')
+          }
         `
       }
     ]
   , invalid: [
       {
         code: `
-          const foo = require('../test/foo')
+          const foo = require('../test/foo');
           if (bar) {
             const baz = require('./baz');
           }
+          registerTransform(require('../transforms/parse'))
+          module.exports = require('../foo/bar');
         `
       , errors: [
           {message: 'Missing file extension for local module.'}
+        , {message: 'Missing file extension for local module.'}
+        , {message: 'Missing file extension for local module.'}
         , {message: 'Missing file extension for local module.'}
         ]
       }


### PR DESCRIPTION
Require file extension rule was using `VariableDeclaration` to identify require usage. This did not catch require usage in expressions.
This PR updates require check to use CallExpression - which covers both expression and assignment usage.

Fixes: #6 