### PR TITLE
chore(deps)!: eslint@9

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -8,6 +8,7 @@ reporter: classic
 nyc-arg:
 - --all=true
 - --exclude=test/
+- --exclude=eslint.config.js
 output-file: .tap-output
 coverage-report:
 - text

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,11 +5,18 @@ def REPO = "logdna/${PROJECT_NAME}"
 def TRIGGER_PATTERN = ".*@logdnabot.*"
 def CURRENT_BRANCH = [env.CHANGE_BRANCH, env.BRANCH_NAME]?.find{branch -> branch != null}
 def DEFAULT_BRANCH = 'main'
+def BUILD_SLUG = slugify(BUILD_TAG)
 
 pipeline {
-  agent none
+  agent {
+      node {
+          label 'ec2-fleet'
+          customWorkspace("/tmp/workspace/${BUILD_SLUG}")
+      }
+  }
 
   options {
+    timeout time: 1, unit: 'HOURS'
     timestamps()
     ansiColor 'xterm'
   }
@@ -36,7 +43,7 @@ pipeline {
         axes {
           axis {
             name 'NODE_VERSION'
-            values '12', '14', '15'
+            values '20', '22', '24'
           }
         }
 
@@ -91,7 +98,7 @@ pipeline {
 
       agent {
         docker {
-          image "us.gcr.io/logdna-k8s/node:12-ci"
+          image "us.gcr.io/logdna-k8s/node:22-ci"
           customWorkspace "${PROJECT_NAME}-${BUILD_NUMBER}"
         }
       }
@@ -110,7 +117,7 @@ pipeline {
       steps {
         sh 'mkdir -p .npm'
         sh 'npm install'
-        sh "npm run release -- --dry-run --no-ci --branches ${CURRENT_BRANCH}"
+        sh "npm run release:dry"
       }
     }
 
@@ -122,7 +129,7 @@ pipeline {
 
       agent {
         docker {
-          image "us.gcr.io/logdna-k8s/node:12-ci"
+          image "us.gcr.io/logdna-k8s/node:22-ci"
           customWorkspace "${PROJECT_NAME}-${BUILD_NUMBER}"
         }
       }

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 > ESlint plugin containing a collection of rules for enforcing code style at LogDNA
 
+## Requirements
+
+- ESLint >= 9.0.0
+
 ## Installation
 
 **Requires eslint also**
@@ -17,26 +21,37 @@ npm install eslint-plugin-logdna eslint --save-dev
 
 ## Usage
 
-Add `logdna` to the plugins section of your ESLint configuration. You can omit 
-the `eslint-plugin-` prefix. Then you can configure the rules you want to use:
+### Using flat config (eslint.config.js)
 
-```json
-{
-  "plugins": [
-    "logdna"
-  ],
-  "rules": {
-    "logdna/grouped-require": 2,
-    "logdna/require-file-extension": 2,
-    "logdna/tap-no-deprecated-aliases": 2,
-    "logdna/tap-consistent-assertions": [2, {
-      "preferredMap": {
-        "error": "error",
-        "equal": "strictEqual",
-      }
-    }]
+Import the plugin and use it in your flat config:
+
+```js
+// eslint.config.js
+const logdna = require('eslint-plugin-logdna')
+
+module.exports = [
+  {
+    plugins: {
+      logdna
+    },
+    rules: {
+      'logdna/grouped-require': 'error',
+      'logdna/require-file-extension': 'error',
+      'logdna/tap-no-deprecated-aliases': 'error'
+    }
   }
-}
+]
+```
+
+Or use the recommended configuration:
+
+```js
+// eslint.config.js
+const logdna = require('eslint-plugin-logdna')
+
+module.exports = [
+  logdna.configs.recommended
+]
 ```
 
 ## Rules
@@ -98,18 +113,23 @@ test('foo', async (t) => {
 > Enforce consistent aliases for tap assertions
 
 ```js
-// {
-//   "plugins": [
-//     "logdna"
-//   ],
-//   "rules": {
-//     "logdna/tap-consistent-assertions": {
-//       "preferredMap": {
-//         "equal": "strictEqual"
-//       }
-//     }
-//   }
-// }
+// eslint.config.js
+const logdna = require('eslint-plugin-logdna')
+
+module.exports = [
+  {
+    plugins: {
+      logdna
+    },
+    rules: {
+      'logdna/tap-consistent-assertions': ['error', {
+        preferredMap: {
+          equal: 'strictEqual'
+        }
+      }]
+    }
+  }
+]
 
 // Bad
 test('foo', async (t) => {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,35 @@
+'use strict'
+
+// ESLint flat config for the plugin project itself
+module.exports = [
+  {
+    ignores: [
+      'node_modules/**',
+      'coverage/**'
+    ]
+  },
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'commonjs'
+    },
+    rules: {
+      // Add any project-specific rules here
+      'no-unused-vars': 'error',
+      'no-console': 'warn'
+    }
+  },
+  // Use our own plugin's rules for this project
+  {
+    files: ['lib/**/*.js'],
+    plugins: {
+      logdna: require('./lib/index.js')
+    },
+    rules: {
+      'logdna/grouped-require': 'error',
+      'logdna/require-file-extension': 'error'
+    }
+  }
+]
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,32 @@
 'use strict'
 
+const rules = require('./rules/index.js')
+const pkg = require('../package.json')
+
+// ESLint v9+ flat config plugin format
 module.exports = {
-  rules: require('./rules/index.js')
+  // Plugin metadata
+  meta: {
+    name: pkg.name
+  , version: pkg.version
+  }
+
+  // Rule definitions
+, rules
+
+  // Flat config presets
+, configs: {}
+}
+
+// Flat config recommended preset
+module.exports.configs.recommended = {
+  name: 'logdna/recommended'
+, plugins: {
+    logdna: module.exports
+  }
+, rules: {
+    'logdna/grouped-require': 'error'
+  , 'logdna/require-file-extension': 'error'
+  , 'logdna/tap-no-deprecated-aliases': 'error'
+  }
 }

--- a/lib/rules/grouped-require.js
+++ b/lib/rules/grouped-require.js
@@ -13,7 +13,7 @@ const DEFAULT_SORT_ORDER = ['static', 'builtin', 'contrib', 'scoped', 'local']
 
 module.exports = {
   meta: {
-    type: 'suggestion'
+    type: 'problem'
   , docs: {
       description: 'Enforce grouped require declarations by scope'
     , category: 'LogDNA'
@@ -35,6 +35,9 @@ module.exports = {
       , additionalProperties: false
       }
     ]
+  , messages: {
+      wrongOrder: "Expected '{{syntaxA}}' require before '{{syntaxB}}' require."
+    }
   }
 , create(context) {
     const configuration = context.options[0] || {}
@@ -63,7 +66,7 @@ module.exports = {
           if (currentIndex < previousIndex) {
             context.report({
               node
-            , message: "Expected '{{syntaxA}}' require before '{{syntaxB}}' require."
+            , messageId: 'wrongOrder'
             , data: {
                 syntaxA: typeOrder[currentIndex]
               , syntaxB: typeOrder[previousIndex]

--- a/lib/rules/require-file-extension.js
+++ b/lib/rules/require-file-extension.js
@@ -10,10 +10,13 @@ const REQUIRE_EXTENSIONS = new Set(['js', 'json', 'node'])
 
 module.exports = {
   meta: {
-    type: 'suggestion'
+    type: 'problem'
   , docs: {
       description: 'Enforce file extension for local modules/files'
     , category: 'LogDNA'
+    }
+  , messages: {
+      missingExtension: 'Missing file extension for local module.'
     }
   }
 , create(context) {
@@ -35,7 +38,7 @@ module.exports = {
           if (!hasExtension) {
             context.report({
               node
-            , message: 'Missing file extension for local module.'
+            , messageId: 'missingExtension'
             })
           }
         }

--- a/lib/rules/tap-consistent-assertions.js
+++ b/lib/rules/tap-consistent-assertions.js
@@ -7,7 +7,7 @@ const DEFAULT_CALLEE_PATTERN = '/^t+$/'
 
 module.exports = {
   meta: {
-    type: 'suggestion'
+    type: 'problem'
   , fixable: 'code'
   , deprecated: true
   , docs: {
@@ -28,6 +28,9 @@ module.exports = {
       , additionalProperties: false
       }
     ]
+  , messages: {
+      usePreferredAlias: 'The "{{preferred}}" alias is preferred over "{{method}}"'
+    }
   }
 , create(context) {
     const {
@@ -35,9 +38,7 @@ module.exports = {
     , calleePattern = DEFAULT_CALLEE_PATTERN
     } = context.options[0] || {}
 
-    if (Object.keys(preferredMap).length === 0) {
-      return {}
-    }
+    if (Object.keys(preferredMap).length === 0) return {}
 
     const targetMap = Object.keys(preferredMap).reduce((map, primary) => {
       if (synonyms[primary]) {
@@ -62,7 +63,11 @@ module.exports = {
         if (preferred && preferred !== method) {
           context.report({
             node
-          , message: `The "${preferred}" alias is preferred over "${method}"`
+          , messageId: 'usePreferredAlias'
+          , data: {
+              method
+            , preferred
+            }
           , fix(fixer) {
               return fixer.replaceText(node.callee.property, preferred)
             }

--- a/lib/rules/tap-no-deprecated-aliases.js
+++ b/lib/rules/tap-no-deprecated-aliases.js
@@ -7,7 +7,7 @@ const DEFAULT_CALLEE_PATTERN = '/^t+$/'
 
 module.exports = {
   meta: {
-    type: 'suggestion'
+    type: 'problem'
   , fixable: 'code'
   , docs: {
       description: 'Prevent usage of deprecated tap aliases (>= tap@15.0.0)'
@@ -24,6 +24,9 @@ module.exports = {
       , additionalProperties: false
       }
     ]
+  , messages: {
+      deprecatedAlias: 'The "{{alias}}" alias is deprecated in favor of "{{main}}"'
+    }
   }
 , create(context) {
     const {
@@ -46,7 +49,11 @@ module.exports = {
         if (main && main !== alias) {
           context.report({
             node
-          , message: `The "${alias}" alias is deprecated in favor of "${main}"`
+          , messageId: 'deprecatedAlias'
+          , data: {
+              alias
+            , main
+            }
           , fix(fixer) {
               return fixer.replaceText(node.callee.property, main)
             }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "tap": "tap",
     "pretest": "npm run lint",
     "test": "tap",
-    "release": "semantic-release"
+    "release": "semantic-release",
+    "release:dry": "semantic-release --no-ci --dry-run --branches=${BRANCH_NAME:-main}"
   },
   "dependencies": {
     "dot-prop": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -44,23 +44,18 @@
     "test": "tap",
     "release": "semantic-release"
   },
-  "eslintConfig": {
-    "root": true,
-    "extends": "logdna",
-    "ignorePatterns": [
-      "node_modules/",
-      "coverage/"
-    ]
-  },
   "dependencies": {
     "dot-prop": "^5.3.0",
     "is-builtin-module": "^3.0.0"
   },
   "devDependencies": {
-    "eslint": "^7.20.0",
+    "eslint": "^10.0.0",
     "eslint-config-logdna": "^4.0.2",
     "semantic-release": "^17.3.9",
     "semantic-release-config-logdna": "^1.1.0",
     "tap": "^14.10.8"
+  }
+  , "peerDependencies": {
+    "eslint": ">=9.0.0"
   }
 }

--- a/test/common/bootstrap.js
+++ b/test/common/bootstrap.js
@@ -1,10 +1,22 @@
 'use strict'
 
 const {RuleTester} = require('eslint')
+
+// ESLint v9+ uses languageOptions instead of parserOptions
 const ruleTester = new RuleTester({
-  parserOptions: {
-    ecmaVersion: 2019
+  languageOptions: {
+    ecmaVersion: 2022
   , sourceType: 'script'
+  , globals: {
+      require: 'readonly'
+    , module: 'readonly'
+    , exports: 'writable'
+    , __dirname: 'readonly'
+    , __filename: 'readonly'
+    , process: 'readonly'
+    , console: 'readonly'
+    , Buffer: 'readonly'
+    }
   }
 })
 

--- a/test/lib/rules/grouped-require.js
+++ b/test/lib/rules/grouped-require.js
@@ -67,8 +67,8 @@ test(RULE_NAME, async (t) => {
           }
         `
       , errors: [
-          {message: "Expected 'static' require before 'contrib' require."}
-        , {message: "Expected 'scoped' require before 'local' require."}
+          {messageId: 'wrongOrder'}
+        , {messageId: 'wrongOrder'}
         ]
       }
     ]

--- a/test/lib/rules/require-file-extension.js
+++ b/test/lib/rules/require-file-extension.js
@@ -35,10 +35,10 @@ test(RULE_NAME, async (t) => {
           module.exports = require('../foo/bar');
         `
       , errors: [
-          {message: 'Missing file extension for local module.'}
-        , {message: 'Missing file extension for local module.'}
-        , {message: 'Missing file extension for local module.'}
-        , {message: 'Missing file extension for local module.'}
+          {messageId: 'missingExtension'}
+        , {messageId: 'missingExtension'}
+        , {messageId: 'missingExtension'}
+        , {messageId: 'missingExtension'}
         ]
       }
     ]

--- a/test/lib/rules/tap-consistent-assertions.js
+++ b/test/lib/rules/tap-consistent-assertions.js
@@ -93,9 +93,9 @@ test(RULE_NAME, async (t) => {
           preferredMap: {same: 'deepEqual', equal: 'strictEqual'}
         }]
       , errors: [
-          {message: 'The "strictEqual" alias is preferred over "strict_equals"'}
-        , {message: 'The "deepEqual" alias is preferred over "same"'}
-        , {message: 'The "strictEqual" alias is preferred over "strict_equals"'}
+          {messageId: 'usePreferredAlias'}
+        , {messageId: 'usePreferredAlias'}
+        , {messageId: 'usePreferredAlias'}
         ]
       }
     ]

--- a/test/lib/rules/tap-no-deprecated-aliases.js
+++ b/test/lib/rules/tap-no-deprecated-aliases.js
@@ -37,7 +37,7 @@ test(RULE_NAME, async (t) => {
         })
       `
       , errors: [
-          {message: 'The "deepEqual" alias is deprecated in favor of "same"'}
+          {messageId: 'deprecatedAlias'}
         ]
       }
     , {


### PR DESCRIPTION
eslint 9 introduced several breaking changes to the way plugins are defined and report errors. This change updates the plugin interface to support the rule definition, schemas and top level exports to work with the newer interfaces

BREAKING CHANGE: minimum eslint >= 9

Fixes: #12